### PR TITLE
add code fences to services.md

### DIFF
--- a/src/SERVICES.md
+++ b/src/SERVICES.md
@@ -13,38 +13,38 @@
 ## codepen
 
 - `url`: of the codepen.
-- `tabs`(optional): to be shown by default, separated with commas and no spaces e.g html,result. The default value is 'result'
-- Example: {% codepen https://codepen.io/Dillion/pen/jddJSs tab=html,css %}
+- `tabs`(optional): to be shown by default, separated with commas and no spaces e.g `html,result`. The default value is `result`
+- Example: `{% codepen https://codepen.io/Dillion/pen/jddJSs tab=html,css %}`
 
 ## codesandbox
 
-- `hash`: of the box. Usually found at the end of the url. e.g the url 'https://codesandbox.io/s/admiring-rosalind-d' has the hash **admiring-rosalind-d**
-- Example: {% codesandbox admiring-rosalind-d %}
+- `hash`: of the box. Usually found at the end of the url. e.g the url `https://codesandbox.io/s/admiring-rosalind-d` has the hash **admiring-rosalind-d**
+- Example: `{% codesandbox admiring-rosalind-d %}`
 
 ## youtube
 
-- `hash`: of the video. Usually found at the end of the url. e.g the url 'https://www.youtube.com/watch?v=U9VF-4euyRoJJ' has the hash **U9VF-4euyRoJJ**
-- Example: {% youtube U9VF-4euyRoJJ %}
+- `hash`: of the video. Usually found at the end of the url. e.g the url `https://www.youtube.com/watch?v=U9VF-4euyRoJJ` has the hash **U9VF-4euyRoJJ**
+- Example: `{% youtube U9VF-4euyRoJJ %}`
 
 ## google-slides
 
 **Note that** you'd need to get a public URL from google slides to embed the slide (not the presentation URL). To do this, you'll select "Publish to the web" in the file menu, select publish then get the public URL which you'd use.
 
 - `public_url`: of the presentation which has been published.
-- Example: {% google-slides https://docs.google.com/presentation/d/e/... %}
+- Example: `{% google-slides https://docs.google.com/presentation/d/e/... %}`
 
 ## soundcloud
 
 - `url`: of the song.
-- Example: {% soundcloud https://soundcloud.com/... %}
+- Example: `{% soundcloud https://soundcloud.com/... %}`
 
 ## slides
 
 - `url`: of the of the slide (slide.com)
-- Example: {% slides https://slides.com/dillionme... %}
+- Example: `{% slides https://slides.com/dillionme... %}`
 
 ## jsfiddle
 
 - `url`: of the of the fiddle.
-- `theme`(optional): which is either light or dark. Default is light.
-- Example: {% jsfiddle https://jsfiddle.net/dillion... theme=dark %}
+- `theme`(optional): which is either `light` or `dark`. Default is `light`.
+- Example: `{% jsfiddle https://jsfiddle.net/dillion... theme=dark %}`


### PR DESCRIPTION
**What**:

reformat `services.md`

**Why**:

otherwise the markdown renderer swallow the `https://` which is needed for the `checkUrl` function

**How**:

added code fences
